### PR TITLE
cmd/*,internal/slogext: log test logging synchronously with tags

### DIFF
--- a/cmd/runner/main_test.go
+++ b/cmd/runner/main_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -21,7 +22,6 @@ import (
 	"golang.org/x/sys/execabs"
 
 	runner "github.com/kortschak/dex/cmd/runner/api"
-	"github.com/kortschak/dex/internal/locked"
 	"github.com/kortschak/dex/internal/slogext"
 	"github.com/kortschak/dex/rpc"
 )
@@ -40,16 +40,18 @@ func TestDaemon(t *testing.T) {
 
 	for _, network := range []string{"unix", "tcp"} {
 		t.Run(network, func(t *testing.T) {
+			verbose := slogext.NewAtomicBool(*verbose)
 			var (
-				level        slog.LevelVar
-				kernLogBuf   locked.BytesBuffer
-				runnerLogBuf locked.BytesBuffer
+				level slog.LevelVar
+				buf   bytes.Buffer
 			)
-			level.Set(slog.LevelDebug)
-			log := slog.New(slogext.NewJSONHandler(&kernLogBuf, &slogext.HandlerOptions{
+			h := slogext.NewJSONHandler(&buf, &slogext.HandlerOptions{
 				Level:     &level,
 				AddSource: slogext.NewAtomicBool(*lines),
-			}))
+			})
+			g := slogext.NewPrefixHandlerGroup(&buf, h)
+			level.Set(slog.LevelDebug)
+			log := slog.New(g.NewHandler("🔷 "))
 
 			ctx, cancel := context.WithTimeoutCause(context.Background(), 20*time.Second, errors.New("test waited too long"))
 			defer cancel()
@@ -64,9 +66,7 @@ func TestDaemon(t *testing.T) {
 				select {
 				case <-ctx.Done():
 					t.Error("failed to close server")
-					*verbose = true
-					t.Logf("kernel log:\n%s\n", &kernLogBuf)
-					t.Logf("runner log:\n%s", &runnerLogBuf)
+					verbose.Store(true)
 				case <-closed:
 				}
 			}()
@@ -77,14 +77,13 @@ func TestDaemon(t *testing.T) {
 				}
 				close(closed)
 
-				if *verbose {
-					t.Logf("kernel log:\n%s\n", &kernLogBuf)
-					t.Logf("runner log:\n%s", &runnerLogBuf)
+				if verbose.Load() {
+					t.Logf("log:\n%s\n", &buf)
 				}
 			}()
 
 			uid := rpc.UID{Module: "runner"}
-			err = kernel.Spawn(ctx, os.Stdout, &runnerLogBuf, uid.Module,
+			err = kernel.Spawn(ctx, os.Stdout, g.NewHandler("🔶 "), uid.Module,
 				exePath, "-log", level.Level().String(), fmt.Sprintf("-lines=%t", *lines),
 			)
 			if err != nil {

--- a/cmd/worklog/main_test.go
+++ b/cmd/worklog/main_test.go
@@ -48,16 +48,18 @@ func TestDaemon(t *testing.T) {
 
 	for _, network := range []string{"unix", "tcp"} {
 		t.Run(network, func(t *testing.T) {
+			verbose := slogext.NewAtomicBool(*verbose)
 			var (
-				level         slog.LevelVar
-				kernLogBuf    locked.BytesBuffer
-				watcherLogBuf locked.BytesBuffer
+				level slog.LevelVar
+				buf   bytes.Buffer
 			)
-			level.Set(slog.LevelDebug)
-			log := slog.New(slogext.NewJSONHandler(&kernLogBuf, &slogext.HandlerOptions{
+			h := slogext.NewJSONHandler(&buf, &slogext.HandlerOptions{
 				Level:     &level,
 				AddSource: slogext.NewAtomicBool(*lines),
-			}))
+			})
+			g := slogext.NewPrefixHandlerGroup(&buf, h)
+			level.Set(slog.LevelDebug)
+			log := slog.New(g.NewHandler("🔷 "))
 
 			ctx, cancel := context.WithTimeoutCause(context.Background(), 20*time.Second, errors.New("test waited too long"))
 			defer cancel()
@@ -72,9 +74,7 @@ func TestDaemon(t *testing.T) {
 				select {
 				case <-ctx.Done():
 					t.Error("failed to close server")
-					*verbose = true
-					t.Logf("kernel log:\n%s\n", &kernLogBuf)
-					t.Logf("worklog log:\n%s", &watcherLogBuf)
+					verbose.Store(true)
 				case <-closed:
 				}
 			}()
@@ -85,14 +85,13 @@ func TestDaemon(t *testing.T) {
 				}
 				close(closed)
 
-				if *verbose {
-					t.Logf("kernel log:\n%s\n", &kernLogBuf)
-					t.Logf("worklog log:\n%s", &watcherLogBuf)
+				if verbose.Load() {
+					t.Logf("log:\n%s\n", &buf)
 				}
 			}()
 
 			uid := rpc.UID{Module: "worklog"}
-			err = kernel.Spawn(ctx, os.Stdout, &watcherLogBuf, uid.Module,
+			err = kernel.Spawn(ctx, os.Stdout, g.NewHandler("🔶 "), uid.Module,
 				exePath, "-log", level.Level().String(), fmt.Sprintf("-lines=%t", *lines),
 			)
 			if err != nil {


### PR DESCRIPTION
Also fix data race on the verbose flag and don't double print logs when the server fails to stop.