### PR TITLE
cmd/*,internal/slogext,rpc: various improvements

### DIFF
--- a/cmd/rest/main_test.go
+++ b/cmd/rest/main_test.go
@@ -125,7 +125,10 @@ func TestDaemon(t *testing.T) {
 			}
 			// Catch failures to terminate.
 			closed := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				select {
 				case <-ctx.Done():
 					t.Error("failed to close server")
@@ -139,7 +142,7 @@ func TestDaemon(t *testing.T) {
 					t.Errorf("failed to close kernel: %v", err)
 				}
 				close(closed)
-
+				wg.Wait()
 				if verbose.Load() {
 					t.Logf("log:\n%s\n", &buf)
 				}

--- a/cmd/runner/main_test.go
+++ b/cmd/runner/main_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -62,7 +63,10 @@ func TestDaemon(t *testing.T) {
 			}
 			// Catch failures to terminate.
 			closed := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				select {
 				case <-ctx.Done():
 					t.Error("failed to close server")
@@ -76,7 +80,7 @@ func TestDaemon(t *testing.T) {
 					t.Errorf("failed to close kernel: %v", err)
 				}
 				close(closed)
-
+				wg.Wait()
 				if verbose.Load() {
 					t.Logf("log:\n%s\n", &buf)
 				}

--- a/cmd/watcher/main_test.go
+++ b/cmd/watcher/main_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -69,7 +70,10 @@ func TestDaemon(t *testing.T) {
 			}
 			// Catch failures to terminate.
 			closed := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				select {
 				case <-ctx.Done():
 					t.Error("failed to close server")
@@ -83,7 +87,7 @@ func TestDaemon(t *testing.T) {
 					t.Errorf("failed to close kernel: %v", err)
 				}
 				close(closed)
-
+				wg.Wait()
 				if verbose.Load() {
 					t.Logf("log:\n%s\n", &buf)
 				}

--- a/cmd/worklog/main_test.go
+++ b/cmd/worklog/main_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -70,7 +71,10 @@ func TestDaemon(t *testing.T) {
 			}
 			// Catch failures to terminate.
 			closed := make(chan struct{})
+			var wg sync.WaitGroup
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				select {
 				case <-ctx.Done():
 					t.Error("failed to close server")
@@ -84,7 +88,7 @@ func TestDaemon(t *testing.T) {
 					t.Errorf("failed to close kernel: %v", err)
 				}
 				close(closed)
-
+				wg.Wait()
 				if verbose.Load() {
 					t.Logf("log:\n%s\n", &buf)
 				}

--- a/rpc/kernel.go
+++ b/rpc/kernel.go
@@ -437,6 +437,7 @@ func (k *Kernel) Spawn(ctx context.Context, stdout, stderr io.Writer, uid, name 
 	if err != nil {
 		return err
 	}
+	k.log.LogAttrs(ctx, slog.LevelDebug, "started", slog.String("uid", uid), slog.Int("pid", cmd.Process.Pid))
 
 	d := &daemon{uid: uid, cmd: cmd, ready: make(chan struct{})}
 	k.daemons[uid] = d


### PR DESCRIPTION
- fix logic race in tests that allow a call to `t.Fail` after tests have returned in some cases.
- improve  formatting of passthrough text in prefix groups (still not ideal: non-atomic lines written by original writer are split)
- log PIDs of spawned daemons