### PR TITLE
cmd/rest: allow rest services to be associated with a device

### DIFF
--- a/cmd/rest/api/api.go
+++ b/cmd/rest/api/api.go
@@ -24,8 +24,9 @@ type Config struct {
 
 // Service defines service configuration options.
 type Service struct {
-	Name    string `json:"name,omitempty"`
-	Active  *bool  `json:"active,omitempty"`
+	Name    string  `json:"name,omitempty"`
+	Active  *bool   `json:"active,omitempty"`
+	Serial  *string `json:"serial,omitempty"`
 	Options struct {
 		// Service-level server definition.
 		Server Server `json:"server,omitempty"`


### PR DESCRIPTION
rest service requests may need to make kernel calls that depend on the identity of an attached device. For example the kernel utility method, "page_details" requires the requester to be associated in order to be able to return the correct page details.

This can currently be achieved by creating an empty kernel service with the desired serial and then using the "from" field in the returned CEL evaluation note.

	# Empty service to assign serial to.
	[service.kernel_page_details]
	serial = ""

	[service.page_details_rest]
	module = "rest"
	[service.page_details_rest.options.server]
	addr = "localhost:9001"
	request = """
	{
		// Use "from" to alias kernel_page_details service above.
		"from":   {"service":"kernel_page_details"},
		"method": "page_details",
	}
	"""
	response = """
	response.body
	"""

However, if dynamic dispatcher is not required a static serial written into the TOML is significantly simpler.

	[service.page_details_rest]
	module = "rest"
	# Directly assign serial to rest service.
	serial = ""
	[service.page_details_rest.options.server]
	addr = "localhost:9001"
	request = """
	{"method":"page_details"}
	"""
	response = """
	response.body
	"""

For completeness, the context that service.page_details_rest.options.server might be used.

	[kernel]
	device = [{}]
	network = "unix"

	[module.runner]
	path = "runner"
	log_mode = "log"

	[service.page_details]
	module = "runner"
	serial = ""
	listen = [
		{row = 1, col = 1, image = "data:text/plain,pages"},
		{row = 1, col = 1, change = "press", do = "run", args = {path = "bash", args = ["-c", "curl -s -L 'http://localhost:9001'|jq|zenity --text-info --no-wrap"]}}
	]

	[module.rest]
	path = "rest"
	log_mode = "log"